### PR TITLE
Don't swallow the underlying decrypt error

### DIFF
--- a/decrypt-windows-ec2-passwd.py
+++ b/decrypt-windows-ec2-passwd.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
     #Import it
     try:
         key = RSA.importKey(keyLines, passphrase=getpass.getpass('Encrypted Key Password (leave blank if none): '))
-    except ValueError:
-        print "Could not import SSH Key (Is it an RSA key? Is it password protected?)"
+    except ValueError, ex:
+        print "Could not import SSH Key (Is it an RSA key? Is it password protected?): %s" % ex
         sys.exit(-1)
     #Decrypt it
     print ""


### PR DESCRIPTION
If key decryption fails, an error like:

```
Could not import SSH Key (Is it an RSA key? Is it password protected?)
```

is produced. It doesn't contain any info about what actually went wrong in decryption; the exception is swallowed.

Instead, report the real exception afterwards:

```
Could not import SSH Key (Is it an RSA key? Is it password protected?): Unsupport PEM encryption algorithm.
```
