### PR TITLE
Add an OpenSSL based shell script to decrypt passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,19 @@ Encrypted private key. Please enter passphrase:
 Decrypted password: bG7hKK1Kt;8
 ```
 
-(Full credit to [agl](https://github.com/tomrittervg/decrypt-windows-ec2-passwd/pull/2) for the Go version, and [marcin](https://github.com/tomrittervg/decrypt-windows-ec2-passwd/pull/3) for making the Python version accept passphrases)
+For the convenience of UNIX users there's a simple shell script that wraps
+OpenSSL tools to decrypt the password. It supports encrypted private keys in
+several formats including PEM, and can decode the base64 password text from a
+file, supplied on the command line, or from stdin.
+
+```
+decrypt-windows-ec2-passwd.sh ~/.ssh/id_rsa "ercW1ff...9zEw=="
+Enter pass phrase for .ssh/id_rsa:
+bG7hKK1Kt;8
+```
+
+Credits:
+
+* [agl](https://github.com/tomrittervg/decrypt-windows-ec2-passwd/pull/2) for the Go version
+* [marcin](https://github.com/tomrittervg/decrypt-windows-ec2-passwd/pull/3) for making the Python version accept passphrases
+* [ringerc](https://github.com/ringerc) for the shell script

--- a/decrypt-windows-ec2-passwd.sh
+++ b/decrypt-windows-ec2-passwd.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# Quick EC2 password decrypt by Craig Ringer, based on work by "hedgehog" on
+# Stack Overflow (http://stackoverflow.com/a/4982867/398670). Only requires
+# tools preinstalled on most Linux systems, supports encrypted private keys.
+#
+# See also:
+# * http://serverfault.com/q/603984/102814
+
+set -e -u
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 /path/to/key [ \"base64 password text\" | /path/to/password/file | - ]"
+    exit 1
+fi
+
+set -o pipefail
+
+if [ -e "$2" -o "$2" = "-" ]; then
+    # file exists, or user specified stdin
+    cat "$2" | base64 -d | openssl rsautl -decrypt -inkey "$1"
+else
+    # No such file and isn't stdin, assume it's base64
+    echo "$2" | base64 -d | openssl rsautl -decrypt -inkey "$1"
+fi
+echo


### PR DESCRIPTION
Add a convenient shell script that only requires OpenSSL to make life easier for UNIX/Linux users.
