### PR TITLE
Use --decode option instead of -d

### DIFF
--- a/decrypt-windows-ec2-passwd.sh
+++ b/decrypt-windows-ec2-passwd.sh
@@ -18,9 +18,9 @@ set -o pipefail
 
 if [ -e "$2" -o "$2" = "-" ]; then
     # file exists, or user specified stdin
-    cat "$2" | base64 -d | openssl rsautl -decrypt -inkey "$1"
+    cat "$2" | base64 --decode | openssl rsautl -decrypt -inkey "$1"
 else
     # No such file and isn't stdin, assume it's base64
-    echo "$2" | base64 -d | openssl rsautl -decrypt -inkey "$1"
+    echo "$2" | base64 --decode | openssl rsautl -decrypt -inkey "$1"
 fi
 echo


### PR DESCRIPTION
`--decode` option works both on a GNU version of `base64` and on a version that ships with macOS.
Whereas `-d` option is not supported by a macOS version.

Closes #9 